### PR TITLE
debugging - show errno if select returns < 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ rvm:
   - rbx-18mode
   - rbx-19mode
   - 2.0.0
+  - 2.1.0
+  - 2.2.0
 matrix:
   allow_failures:
     - rvm: rbx-18mode

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rake', '~> 0.9.0'
 
 group :test do
   gem "rspec" , "~> 2.11"
-  gem 'eventmachine', '1.0.0'
+  gem 'eventmachine', '1.0.4'
   gem 'evented-spec', '~> 0.9.0'
   gem 'zk-server', '~> 1.0', :git => 'https://github.com/zk-ruby/zk-server.git'
 end

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -68,7 +68,7 @@ Dir.chdir(HERE) do
     # clean up stupid apple rsrc fork bullshit
     FileUtils.rm_f(Dir['**/._*'].select{|p| test(?f, p)})
 
-    Dir.chdir(BUNDLE_PATH) do        
+    Dir.chdir(BUNDLE_PATH) do
       configure = "./configure --prefix=#{HERE} --with-pic --without-cppunit --disable-dependency-tracking #{$EXTRA_CONF} 2>&1"
       configure = "env CFLAGS='#{DEBUG_CFLAGS}' #{configure}" if ZK_DEBUG
 
@@ -85,13 +85,14 @@ end
 Dir.chdir("#{HERE}/lib") do
   %w[st mt].each do |stmt|
     %w[a la].each do |ext|
-      system("cp -f libzookeeper_#{stmt}.#{ext} libzookeeper_#{stmt}_gem.#{ext}") 
+      system("cp -f libzookeeper_#{stmt}.#{ext} libzookeeper_#{stmt}_gem.#{ext}")
     end
   end
 end
 $LIBS << " -lzookeeper_st_gem"
 
 have_func('rb_thread_blocking_region')
+have_func('rb_thread_fd_select')
 
 $CFLAGS << ' -Wall' if ZK_DEV
 create_makefile 'zookeeper_c'

--- a/ext/zkrb.c
+++ b/ext/zkrb.c
@@ -855,6 +855,7 @@ static VALUE method_zkrb_iterate_event_loop(VALUE self) {
   else {
     log_err("select returned an error: rc=%d interest=%d fd=%d pipe_r_fd=%d maxfd=%d irc=%d timeout=%f",
       rc, interest, fd, pipe_r_fd, maxfd, irc, tv.tv_sec + (tv.tv_usec/ 1000.0 / 1000.0));
+    rb_raise(rb_eRuntimeError, "select returned an error: %s", clean_errno());
   }
 
   prc = zookeeper_process(zk->zh, events);

--- a/ext/zkrb.c
+++ b/ext/zkrb.c
@@ -73,6 +73,17 @@
 #include "ruby/io.h"
 #endif
 
+#ifndef HAVE_RB_THREAD_FD_SELECT
+#define rb_fdset_t fd_set
+#define rb_fd_isset(n, f) FD_ISSET(n, f)
+#define rb_fd_init(f)
+#define rb_fd_zero(f)  FD_ZERO(f)
+#define rb_fd_set(n, f)  FD_SET(n, f)
+#define rb_fd_clr(n, f) FD_CLR(n, f)
+#define rb_fd_term(f)
+#define rb_thread_fd_select rb_thread_select
+#endif
+
 #include "zookeeper/zookeeper.h"
 #include <errno.h>
 #include <stdio.h>
@@ -787,8 +798,8 @@ inline static int get_self_pipe_read_fd(VALUE self) {
 static VALUE method_zkrb_iterate_event_loop(VALUE self) {
   FETCH_DATA_PTR(self, zk);
 
-  fd_set rfds, wfds, efds;
-  FD_ZERO(&rfds); FD_ZERO(&wfds); FD_ZERO(&efds);
+  rb_fdset_t rfds, wfds, efds;
+  rb_fd_init(&rfds); rb_fd_init(&wfds); rb_fd_init(&efds);
 
   int fd = 0, interest = 0, events = 0, rc = 0, maxfd = 0, irc = 0, prc = 0;
   struct timeval tv;
@@ -797,14 +808,14 @@ static VALUE method_zkrb_iterate_event_loop(VALUE self) {
 
   if (fd != -1) {
     if (interest & ZOOKEEPER_READ) {
-      FD_SET(fd, &rfds);
+      rb_fd_set(fd, &rfds);
     } else {
-      FD_CLR(fd, &rfds);
+      rb_fd_clr(fd, &rfds);
     }
     if (interest & ZOOKEEPER_WRITE) {
-      FD_SET(fd, &wfds);
+      rb_fd_set(fd, &wfds);
     } else {
-      FD_CLR(fd, &wfds);
+      rb_fd_clr(fd, &wfds);
     }
   } else {
     fd = 0;
@@ -813,22 +824,22 @@ static VALUE method_zkrb_iterate_event_loop(VALUE self) {
   // add our self-pipe to the read set, allow us to wake up in case our attention is needed
   int pipe_r_fd = get_self_pipe_read_fd(self);
 
-  FD_SET(pipe_r_fd, &rfds);
+  rb_fd_set(pipe_r_fd, &rfds);
 
   maxfd = (pipe_r_fd > fd) ? pipe_r_fd : fd;
 
-  rc = rb_thread_select(maxfd+1, &rfds, &wfds, &efds, &tv);
+  rc = rb_thread_fd_select(maxfd+1, &rfds, &wfds, &efds, &tv);
 
   if (rc > 0) {
-    if (FD_ISSET(fd, &rfds)) {
+    if (rb_fd_isset(fd, &rfds)) {
       events |= ZOOKEEPER_READ;
     }
-    if (FD_ISSET(fd, &wfds)) {
+    if (rb_fd_isset(fd, &wfds)) {
       events |= ZOOKEEPER_WRITE;
     }
 
     // we got woken up by the self-pipe
-    if (FD_ISSET(pipe_r_fd, &rfds)) {
+    if (rb_fd_isset(pipe_r_fd, &rfds)) {
       // one event has awoken us, so we clear one event from the pipe
       char b[1];
 
@@ -853,6 +864,8 @@ static VALUE method_zkrb_iterate_event_loop(VALUE self) {
       prc, interest, fd, pipe_r_fd, maxfd, irc, tv.tv_sec + (tv.tv_usec/ 1000.0 / 1000.0));
   }
 
+  rb_fd_term(&rfds);
+  rb_fd_term(&wfds);
   return INT2FIX(prc);
 }
 


### PR DESCRIPTION
I added this line in just to show errno if select returns < 0. Running the tests w/ ree-1.8.7-2012.02 (I for some reason couldn't get vanilla 1.8.7 to install, but this is close enough) this is the output: 

```
=====<([ Zookeeper chrooted it should behave like connection get sync_watch it should behave like all success return values should have a return code of Zookeeper::ZOK ])>=====
I, [2015-01-09T22:29:20.714678 #89044]  INFO -- :     Zookeeper::CZookeeper: initiating connection to localhost:2181/slyphon-zookeeper-chroot
2015-01-09 22:29:20,714:89044:ZOO_INFO@log_env@712: Client environment:zookeeper.version=zookeeper C client 3.4.5
2015-01-09 22:29:20,714:89044:ZOO_INFO@log_env@716: Client environment:host.name=weasel
2015-01-09 22:29:20,714:89044:ZOO_INFO@log_env@723: Client environment:os.name=Darwin
2015-01-09 22:29:20,714:89044:ZOO_INFO@log_env@724: Client environment:os.arch=13.4.0
2015-01-09 22:29:20,714:89044:ZOO_INFO@log_env@725: Client environment:os.version=Darwin Kernel Version 13.4.0: Sun Aug 17 19:50:11 PDT 2014; root:xnu-2422.115.4~1/RELEASE_X86_64
2015-01-09 22:29:20,714:89044:ZOO_INFO@log_env@733: Client environment:user.name=jsimms
2015-01-09 22:29:20,714:89044:ZOO_INFO@log_env@741: Client environment:user.home=/Users/jsimms
2015-01-09 22:29:20,714:89044:ZOO_INFO@log_env@753: Client environment:user.dir=/Users/jsimms/git/github/slyphon/zookeeper
2015-01-09 22:29:20,714:89044:ZOO_INFO@zookeeper_init@786: Initiating client connection, host=localhost:2181/slyphon-zookeeper-chroot sessionTimeout=20001 watcher=0x10f727560 sessionId=0 sessionPasswd=<null> context=0x7fe36dea2980 flags=0
DEBUG 0x7fff7cf9b310:zkrb.c:328: method_zkrb_init, zk_local_ctx: 0x7fe36de89f30, zh: 0x7fe36e219010, queue: 0x7fe36dde28c0, calling_ctx: 0x7fe36dea2980
D, [2015-01-09T22:29:20.715053 #89044] DEBUG -- :     Zookeeper::CZookeeper: #zkc_set_running_and_notify!
D, [2015-01-09T22:29:20.715124 #89044] DEBUG -- :     Zookeeper::CZookeeper: #event_thread_body starting event thread
D, [2015-01-09T22:29:20.715160 #89044] DEBUG -- :     Zookeeper::CZookeeper: init returned!
D, [2015-01-09T22:29:20.715197 #89044] DEBUG -- :     Zookeeper::CZookeeper: event_thread waiting until running: true
D, [2015-01-09T22:29:20.715236 #89044] DEBUG -- :     Zookeeper::CZookeeper: event_thread running: true
2015-01-09 22:29:20,715:89044:ZOO_INFO@check_events@1711: initiated connection to server [fe80::1:2181]
[ERROR] (zkrb.c:857: errno: Bad file descriptor) select returned an error: rc=-1 interest=2 fd=9 pipe_r_fd=5 maxfd=9 irc=0 timeout=6.667000
D, [2015-01-09T22:29:20.715484 #89044] DEBUG -- :     Zookeeper::CZookeeper: #event_thread_body exiting
/Users/jsimms/git/github/slyphon/zookeeper/ext/c_zookeeper.rb:282:in `zkrb_iterate_event_loop': select returned an error: Bad file descriptor (RuntimeError)
    from /Users/jsimms/git/github/slyphon/zookeeper/ext/c_zookeeper.rb:282:in `event_thread_body'
    from /Users/jsimms/git/github/slyphon/zookeeper/ext/c_zookeeper.rb:270:in `to_proc_without_lambda_tracking'
    from /Users/jsimms/git/github/slyphon/zookeeper/ext/c_zookeeper.rb:255:in `initialize'
    from /Users/jsimms/git/github/slyphon/zookeeper/ext/c_zookeeper.rb:255
```

I'm not really sure what changed, there must be a semantic difference between `FD_*` and `rb_fd_*` for one of the arguments.

The exception as-is would be bad, because you would need to `rb_fd_term` all of the things `rb_fd_init`-ed in there before returning, lest we cause a memory leak.

I'm fine with the overall approach btw, and thank you very much for taking the time to do this. I'm sure we'll be able to figure this out. 
